### PR TITLE
Bugs/survey refresh

### DIFF
--- a/labs-ios-starter/Topics/SurveyViewController.swift
+++ b/labs-ios-starter/Topics/SurveyViewController.swift
@@ -21,6 +21,7 @@ class SurveyViewController: UIViewController {
     var surveys: [Survey]?
     var selectedSurveyQuestions: [Question]?
     var isLeader: Bool = false
+    var surveyId: Int?
 
     var index: Int?
 
@@ -32,6 +33,10 @@ class SurveyViewController: UIViewController {
         self.delegate = self
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        updateQuestions()
+    }
+
     private func animate(toggle: Bool) {
         if toggle {
             UIView.animate(withDuration: 0.3) {
@@ -41,6 +46,24 @@ class SurveyViewController: UIViewController {
             UIView.animate(withDuration: 0.3) {
                 self.surveyTableView.isHidden = true
             }
+        }
+    }
+
+    private func updateQuestions() {
+        guard let surveyId = surveyId else { return }
+
+        UserController.shared.fetchSingleSurvey(using: surveyId) { survey in
+            guard let survey = survey, let questions = survey.questions else { return }
+
+            var memberQuestions: [Question] = []
+            for question in questions {
+                if question.leader == false {
+                    memberQuestions.append(question)
+                }
+            }
+
+            self.selectedSurveyQuestions = memberQuestions
+            self.tableView.reloadData()
         }
     }
 
@@ -186,6 +209,9 @@ extension SurveyViewController: UITableViewDataSource, UITableViewDelegate {
             var memberQuestions:[Question] = []
             if let survey = survey,
                let questions = survey.questions {
+                surveyId = survey.surveyid
+                updateQuestions()
+
                 for question in questions {
                     if !(question.leader ?? false) {
                         memberQuestions.append(question)

--- a/labs-ios-starter/Topics/SurveyViewController.swift
+++ b/labs-ios-starter/Topics/SurveyViewController.swift
@@ -206,20 +206,10 @@ extension SurveyViewController: UITableViewDataSource, UITableViewDelegate {
             index = indexPath.row
             animate(toggle: false)
 
-            var memberQuestions:[Question] = []
-            if let survey = survey,
-               let questions = survey.questions {
+            if let survey = survey {
                 surveyId = survey.surveyid
                 updateQuestions()
-
-                for question in questions {
-                    if !(question.leader ?? false) {
-                        memberQuestions.append(question)
-                    }
-                }
             }
-            self.selectedSurveyQuestions = memberQuestions
-            self.tableView.reloadData()
         default:
             let threadViewController = ThreadViewController()
             threadViewController.title = "Thread"

--- a/labs-ios-starter/Topics/TopicTableViewController.swift
+++ b/labs-ios-starter/Topics/TopicTableViewController.swift
@@ -61,8 +61,6 @@ class TopicTableViewController: ShiftableViewController {
                 destionationVC.surveys = surveys
                 destionationVC.defaultSurvey = topics[indexPath.row].defaultSurvey
                 destionationVC.topicId = topics[indexPath.row].topicId
-                destionationVC.defaultSurvey = topics[indexPath.row].defaultSurvey
-                destionationVC.topicId = topics[indexPath.row].topicId
 
                 let userid = UserDefaults.standard.integer(forKey: "User")
                 if userid == topics[indexPath.row].userid {


### PR DESCRIPTION
Users can now see their responses in the SurveyViewController as soon as they respond, instead of having to refresh in the TopicTableViewController. I used the fetchSingleSurvey networking method I had previously written and the surveyId we get once a user selects a survey, to update the question every time the view reappears and every time the user re-selects the survey.

## Before making the Pull Request:

- [x] Is there a description to this pull request that points to a specific user story, feature, or bugfix?
- [x] Are there comments where the code may be unclear?
- [x] Is all dead code, commented out code, etc. removed?
- [ ] Are there tests written for these changes?
- [ ] Does the ReadMe need to be updated?


## Before being merged by the TPL:

- [ ] Has the pull request been reviewed by at least two team members? 
- [ ] Did they leave any comments or suggestions? 
- [ ] Were those suggestions acted on?
- [ ] Are all tests passing?
- [ ] Has the documentation been updated?
