### PR TITLE
Updated the wrapper for context and member questions

### DIFF
--- a/labs-ios-starter/Wizard/ContextQuestionsViewController.swift
+++ b/labs-ios-starter/Wizard/ContextQuestionsViewController.swift
@@ -16,8 +16,6 @@ class ContextQuestionsViewController: ShiftableViewController {
     var selectedContext: Context?
     private var leaderQuestions: [Question] = []
 
-    private var indexToEdit: Int?
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -37,15 +35,34 @@ class ContextQuestionsViewController: ShiftableViewController {
     }
 
     @IBAction func addNewQuestionTapped(_ sender: Any) {
+        updateLeaderQuestions()
         let newQuestion = Question(body: "", type: "TEXT", leader: true)
         leaderQuestions.append(newQuestion)
         tableView.reloadData()
+    }
+
+    private func updateLeaderQuestions() {
+        var cells = [QuestionsTableViewCell]()
+        for cellNumber in 0...tableView.numberOfRows(inSection: 0) {
+            if let cell = tableView.cellForRow(at: IndexPath(row: cellNumber, section: 0)) as? QuestionsTableViewCell {
+                cells.append(cell)
+            }
+        }
+
+        var newLeaderQuestions: [Question] = []
+        for cell in cells {
+            guard let leaderQuestionText = cell.questionBodyTextField.text else { return }
+            let response = Question(body: leaderQuestionText, type: "TEXT", leader: true)
+            newLeaderQuestions.append(response)
+        }
+        leaderQuestions = newLeaderQuestions
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "MemberQuestionsSegue" {
             if let destinationVC = segue.destination as? MemberQuestionsViewController {
                 let survey = Survey()
+                updateLeaderQuestions()
                 survey.questions = leaderQuestions
                 newTopic?.defaultSurvey = survey
                 destinationVC.newTopic = newTopic
@@ -54,17 +71,8 @@ class ContextQuestionsViewController: ShiftableViewController {
         }
     }
 
-    override func textFieldDidBeginEditing(_ textField: UITextField) {
-        textFieldBeingEdited = textField
-        indexToEdit = leaderQuestions.firstIndex(where: { question -> Bool in
-            guard let questionText = textField.text else { return false }
-            return question.body == questionText
-        })
-    }
-
     func textFieldDidEndEditing(_ textField: UITextField) {
-        guard let indexToEdit = indexToEdit, let questionText = textField.text else { return }
-        leaderQuestions[indexToEdit].body = questionText
+        updateLeaderQuestions()
     }
 }
 

--- a/labs-ios-starter/Wizard/MemberQuestionsViewController.swift
+++ b/labs-ios-starter/Wizard/MemberQuestionsViewController.swift
@@ -39,22 +39,31 @@ class MemberQuestionsViewController: ShiftableViewController {
     }
 
     @IBAction func addNewQuestionTapped(_ sender: Any) {
+        updateMemberQuestions()
         let newQuestion = Question(body: "", type: "TEXT", leader: false)
         memberQuestions.append(newQuestion)
         tableView.reloadData()
     }
 
-    override func textFieldDidBeginEditing(_ textField: UITextField) {
-        textFieldBeingEdited = textField
-        indexToEdit = memberQuestions.firstIndex(where: { question -> Bool in
-            guard let questionText = textField.text else { return false }
-            return question.body == questionText
-        })
+    private func updateMemberQuestions() {
+        var cells = [QuestionsTableViewCell]()
+        for cellNumber in 0...tableView.numberOfRows(inSection: 0) {
+            if let cell = tableView.cellForRow(at: IndexPath(row: cellNumber, section: 0)) as? QuestionsTableViewCell {
+                cells.append(cell)
+            }
+        }
+
+        var newMemberQuestions: [Question] = []
+        for cell in cells {
+            guard let memberQuestionText = cell.questionBodyTextField.text else { return }
+            let response = Question(body: memberQuestionText, type: "TEXT", leader: false)
+            newMemberQuestions.append(response)
+        }
+        memberQuestions = newMemberQuestions
     }
 
     func textFieldDidEndEditing(_ textField: UITextField) {
-        guard let indexToEdit = indexToEdit, let questionText = textField.text else { return }
-        memberQuestions[indexToEdit].body = questionText
+        updateMemberQuestions()
     }
 }
 
@@ -80,6 +89,7 @@ extension MemberQuestionsViewController: UITableViewDelegate, UITableViewDataSou
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "TopicCodeSegue" {
             if let destionationVC = segue.destination as? TopicCodeViewController {
+                updateMemberQuestions()
                 newTopic?.defaultSurvey?.questions?.append(contentsOf: memberQuestions)
                 destionationVC.newTopic = newTopic
             }


### PR DESCRIPTION
## Before making the Pull Request:

I made the context and member questions get collected after you press the next and save button as well as when you finish editing and add a new question to make sure that the question gets saved. There shouldn't be any lost questions now.

- [x] Is there a description to this pull request that points to a specific user story, feature, or bugfix?
- [x] Are there comments where the code may be unclear?
- [x] Is all dead code, commented out code, etc. removed?
- [ ] Are there tests written for these changes?
- [ ] Does the ReadMe need to be updated?


## Before being merged by the TPL:

- [ ] Has the pull request been reviewed by at least two team members? 
- [ ] Did they leave any comments or suggestions? 
- [ ] Were those suggestions acted on?
- [ ] Are all tests passing?
- [ ] Has the documentation been updated?
